### PR TITLE
Remove EventSubs before reregister

### DIFF
--- a/src/Actions/RegisterUserTwitchWebhooks.php
+++ b/src/Actions/RegisterUserTwitchWebhooks.php
@@ -20,14 +20,22 @@ class RegisterUserTwitchWebhooks
         $this->apiClient = EventSubClient::http();
     }
 
-    public static function registerAll(Connection $connection)
+    public static function registerAll(Connection $connection, bool $clearBeforeRegister = false)
     {
         $webhooks = config('openoverlay.webhook.twitch.subscribe');
         $handler = new self($connection);
 
+        if($clearBeforeRegister === true) {
+            $handler->clearBroadcasterSubscriptions();
+        }
+
         foreach ($webhooks as $webhookName) {
             $handler->register($webhookName);
         }
+    }
+
+    public function clearBroadcasterSubscriptions() {
+        $this->apiClient->deleteSubByBroadcasterId((string) $this->connection->service_user_id);
     }
 
     public function register(string $type): bool

--- a/src/Listeners/UpdateUserWebhookCalls.php
+++ b/src/Listeners/UpdateUserWebhookCalls.php
@@ -11,6 +11,6 @@ class UpdateUserWebhookCalls implements ShouldQueue
     public function handle(UserConnectionChanged $event)
     {
         $twitchConnection = $event->user->connections()->where('service', 'twitch')->first();
-        RegisterUserTwitchWebhooks::registerAll($twitchConnection);
+        RegisterUserTwitchWebhooks::registerAll($twitchConnection, true);
     }
 }

--- a/src/Models/Twitch/EventSubscription.php
+++ b/src/Models/Twitch/EventSubscription.php
@@ -1,0 +1,46 @@
+<?php
+
+
+namespace Redbeed\OpenOverlay\Models\Twitch;
+
+
+use Carbon\Carbon;
+
+class EventSubscription
+{
+    /** @var string */
+    public $id;
+
+    /** @var string */
+    public $status;
+
+    /** @var string */
+    public $type;
+
+    /** @var int */
+    public $version;
+
+    /** @var array */
+    public $condition;
+
+    /** @var Carbon */
+    public $createdAt;
+
+    /** @var array */
+    public $transport;
+
+    public static function createFromTwitch(array $twitchData): self
+    {
+        $model = new self();
+
+        $model->id = $twitchData['id'];
+        $model->status = $twitchData['status'];
+        $model->type = $twitchData['type'];
+        $model->version = $twitchData['version'];
+        $model->condition = $twitchData['condition'];
+        $model->createdAt = Carbon::parse($twitchData['created_at']);
+        $model->transport = $twitchData['transport'];
+
+        return $model;
+    }
+}

--- a/src/Service/Twitch/ApiClient.php
+++ b/src/Service/Twitch/ApiClient.php
@@ -102,7 +102,7 @@ class ApiClient
      * @param string $method
      * @param string $url
      *
-     * @return mixed
+     * @return array
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function request(string $method, string $url)


### PR DESCRIPTION
Problem was that when you "reconnect" your account with the app you will end up in double event web calls when you already subscribe to EventSub of Twitch.