### PR TITLE
Remove "Beta" Version for channel.raid

### DIFF
--- a/src/Actions/RegisterUserTwitchWebhooks.php
+++ b/src/Actions/RegisterUserTwitchWebhooks.php
@@ -43,11 +43,6 @@ class RegisterUserTwitchWebhooks
     {
         $version = '1';
 
-        // @todo: remove if channel.raid is not in beta anymore
-        if ($type === 'channel.raid') {
-            $version = 'beta';
-        }
-
         $jsonResponse = $this->apiClient->subscribe(
             $type,
             route('open_overlay.connection.webhook'),


### PR DESCRIPTION
Event `channel.raid` is not in Beta anymore